### PR TITLE
This should automatically create the right script for both windows and linux.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,11 @@ from setuptools import setup, find_packages
 setup(
     name = "modm-lbuild",
     version = "0.3",
-    scripts = ['scripts/lbuild'],
+    entry_points={
+        'console_scripts': [
+            'lbuild = lbuild.main:main',
+        ],
+    },
 
     packages = find_packages(exclude=["test"]),
 


### PR DESCRIPTION
Using the automatic script creation [link](https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation) will help providing a uniform experience in both Windows and Linux. Please test the installation under linux, with this commit.   